### PR TITLE
update throughput model

### DIFF
--- a/data/throughput/README.md
+++ b/data/throughput/README.md
@@ -3,10 +3,10 @@
 This directory `throughput` contains the following files:
 
 * README.md (this file) : some explanation
-* pfs_thr_20151204_ext_all_blu.dat : transmission curve of blue arm
-* pfs_thr_20151204_ext_all_red.dat : transmission curve of red arm
-* pfs_thr_20151204_ext_all_nir.dat : transmission curve of NIR arm
-* pfs_thr_20151204_ext_all_mid.dat : transmission curve of red arm in medium resolution (MR) mode
+* pfs_thr_20201231_ext_all_blu.dat : transmission curve of blue arm
+* pfs_thr_20201231_ext_all_red.dat : transmission curve of red arm
+* pfs_thr_20201231_ext_all_nir.dat : transmission curve of NIR arm
+* pfs_thr_20201231_ext_all_mid.dat : transmission curve of red arm in medium resolution (MR) mode
 
 They are *roughly* consistent with the current throughput model in the `spt_ExposureTimeCalculator`.
 

--- a/data/throughput/pfs_thr_20201231_ext_all_blu.dat
+++ b/data/throughput/pfs_thr_20201231_ext_all_blu.dat
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:35bb0133e236854be678cb884989c74b5da4bc18e7d6577cfe9f2d0a1b1fd586
+size 393501

--- a/data/throughput/pfs_thr_20201231_ext_all_mid.dat
+++ b/data/throughput/pfs_thr_20201231_ext_all_mid.dat
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:79ea16bd4ecd52fac57f1e154c1d80368fff972365dcfc9c1f51abe841902670
+size 282163

--- a/data/throughput/pfs_thr_20201231_ext_all_nir.dat
+++ b/data/throughput/pfs_thr_20201231_ext_all_nir.dat
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:abe5262ba2d11ad158b37da76980456dba8d5aa86e575ba371108ec680c41e11
+size 452449

--- a/data/throughput/pfs_thr_20201231_ext_all_red.dat
+++ b/data/throughput/pfs_thr_20201231_ext_all_red.dat
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:048fdf1de5d567e557c0a75f62c75763f6024a50b2be7261fc929f13b6883676
+size 465549


### PR DESCRIPTION
- update throughput model consistent with the latest ETC (version 20201231)
- 0.1nm sampling in all arm 